### PR TITLE
PHP's function substr calls unreadable characters, because it cuts mu…

### DIFF
--- a/plugins/Referrers/Columns/ReferrerName.php
+++ b/plugins/Referrers/Columns/ReferrerName.php
@@ -38,10 +38,12 @@ class ReferrerName extends Base
         $information = $this->getReferrerInformationFromRequest($request);
 
         if (!empty($information['referer_name'])) {
-
-            return substr($information['referer_name'], 0, 70);
+            if (function_exists('mb_substr')) {
+                return mb_substr($information['referer_name'], 0, 70, 'UTF-8');
+            } else {
+                return substr($information['referer_name'], 0, 70);
+            }
         }
-
         return $information['referer_name'];
     }
 


### PR DESCRIPTION
…ltibyte characters without boundary. And MySQL's varchar has a number of multibyte characters - not bytes.
